### PR TITLE
Delete Config Files with `make purge`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ link:
 uninstall:
 	rm $(dest)/$(exec)
 
-purge:
+purge: uninstall
 	rm ~/.psc.yml
 	rm ~/.psc_credentials.yml

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,6 @@ link:
 	ln -s $(realpath $(exec)) $(dest)
 
 uninstall:
+	rm ~/.psc.yml
+	rm ~/.psc_credentials.yml
 	rm $(dest)/$(exec)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ link:
 	ln -s $(realpath $(exec)) $(dest)
 
 uninstall:
+	rm $(dest)/$(exec)
+
+purge:
 	rm ~/.psc.yml
 	rm ~/.psc_credentials.yml
-	rm $(dest)/$(exec)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ make uninstall
 ```
 Any of these commands may require root privileges depending on your environment.
 
-To cleanup credentials located at root (you should run after uninstall):
+To cleanup credentials located at root and uninstall the application run:
 
 `make purge`
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ make uninstall
 ```
 Any of these commands may require root privileges depending on your environment.
 
+To cleanup credentials located at root (you should run after uninstall):
+
+`make purge`
+
 ## Use
 To view all grades:
 ```sh


### PR DESCRIPTION
Due to the fact that very important credentials are held in these config files, they should be deleted upon uninstall.